### PR TITLE
fix: switch radarr and sonarr probes from TCP to HTTP

### DIFF
--- a/k8s/clusters/homelabk8s01/apps/arr/radarr/application.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/radarr/application.yml
@@ -42,10 +42,34 @@ spec:
                 probes:
                   liveness:
                     enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /ping
+                        port: 7878
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
                   readiness:
                     enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /ping
+                        port: 7878
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
                   startup:
                     enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /ping
+                        port: 7878
+                      periodSeconds: 5
+                      timeoutSeconds: 5
+                      failureThreshold: 30
 
         service:
           main:

--- a/k8s/clusters/homelabk8s01/apps/arr/sonarr/application.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/sonarr/application.yml
@@ -42,10 +42,34 @@ spec:
                 probes:
                   liveness:
                     enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /ping
+                        port: 8989
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
                   readiness:
                     enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /ping
+                        port: 8989
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
                   startup:
                     enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /ping
+                        port: 8989
+                      periodSeconds: 5
+                      timeoutSeconds: 5
+                      failureThreshold: 30
 
         service:
           main:


### PR DESCRIPTION
## What
Switch liveness, readiness, and startup probes for Radarr and Sonarr from the default `tcp-socket` to `httpGet /ping`.

## Why
Radarr became unresponsive 4+ times in one hour (2026-03-25 evening). Each time the pod stayed Running because the TCP liveness probe passed — the process was listening on the port but the HTTP layer was hung (connections accepted, no response). Manual restarts were required every time.

HTTP probes will catch this failure mode: if `/ping` does not return 200 within 5 seconds, Kubernetes will automatically restart the pod.

## Details
- **Liveness/Readiness:** `httpGet /ping`, 10s period, 5s timeout, 3 failures to restart
- **Startup:** `httpGet /ping`, 5s period, 5s timeout, 30 failures (allows up to 150s for initial startup — linuxserver.io images can be slow on first boot)
- Applied to both Radarr (port 7878) and Sonarr (port 8989) since both use the same image pattern and had the same issue

## Rollback
Revert this PR — pods will go back to TCP probes. No data impact.