### PR TITLE
fix: increase arr liveness/readiness probe timeout to 10s

### DIFF
--- a/k8s/clusters/homelabk8s01/apps/arr/radarr/application.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/radarr/application.yml
@@ -48,7 +48,7 @@ spec:
                         path: /ping
                         port: 7878
                       periodSeconds: 10
-                      timeoutSeconds: 5
+                      timeoutSeconds: 10
                       failureThreshold: 3
                   readiness:
                     enabled: true
@@ -58,7 +58,7 @@ spec:
                         path: /ping
                         port: 7878
                       periodSeconds: 10
-                      timeoutSeconds: 5
+                      timeoutSeconds: 10
                       failureThreshold: 3
                   startup:
                     enabled: true

--- a/k8s/clusters/homelabk8s01/apps/arr/sonarr/application.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/sonarr/application.yml
@@ -48,7 +48,7 @@ spec:
                         path: /ping
                         port: 8989
                       periodSeconds: 10
-                      timeoutSeconds: 5
+                      timeoutSeconds: 10
                       failureThreshold: 3
                   readiness:
                     enabled: true
@@ -58,7 +58,7 @@ spec:
                         path: /ping
                         port: 8989
                       periodSeconds: 10
-                      timeoutSeconds: 5
+                      timeoutSeconds: 10
                       failureThreshold: 3
                   startup:
                     enabled: true


### PR DESCRIPTION
## What
Increase liveness and readiness probe `timeoutSeconds` from 5 to 10 for Radarr and Sonarr.

## Why
Radarr has been crash-looping all evening — 3+ liveness restarts every ~10 minutes. The root cause is NFS latency spikes from the NAS (192.168.1.158) causing SQLite WAL I/O stalls. When NFS is slow, the `/ping` endpoint blocks on a DB health check and exceeds the 5s timeout. Kubelet kills the container, it restarts, works for a few minutes, then NFS hiccups again.

A 10s timeout gives SQLite enough headroom to complete I/O during NFS latency spikes without triggering unnecessary restarts. The probe still catches genuine application hangs (3 failures × 10s = 30s detection time, up from 15s — still well within acceptable bounds).

## Impact
- Liveness detection window: 15s → 30s (still fast enough for auto-recovery)
- Reduces restart churn during NFS latency events
- Applied to both Radarr and Sonarr (same NFS backend, same failure pattern)

## Rollback
Revert this PR to restore 5s timeouts.