### PR TITLE
fix: replace unsupported default function in alertmanager slack template

### DIFF
--- a/k8s/clusters/homelabk8s01/infrastructure/kube-prometheus-stack/application.yml
+++ b/k8s/clusters/homelabk8s01/infrastructure/kube-prometheus-stack/application.yml
@@ -136,8 +136,8 @@ spec:
                     text: |-
                       {{ range .Alerts }}
                       *Alert:* {{ .Labels.alertname }} - `{{ .Labels.severity }}`
-                      *Namespace:* {{ .Labels.namespace | default "cluster-wide" }}
-                      *Description:* {{ .Annotations.description | default .Annotations.summary | default "No description" }}
+                      *Namespace:* {{ if .Labels.namespace }}{{ .Labels.namespace }}{{ else }}cluster-wide{{ end }}
+                      *Description:* {{ if .Annotations.description }}{{ .Annotations.description }}{{ else if .Annotations.summary }}{{ .Annotations.summary }}{{ else }}No description{{ end }}
                       {{ if .Labels.node }}*Node:* {{ .Labels.node }}{{ end }}
                       {{ end }}
                     color: '{{ if eq .Status "firing" }}{{ if eq .CommonLabels.severity "critical" }}danger{{ else }}warning{{ end }}{{ else }}good{{ end }}'


### PR DESCRIPTION
## What
Replace `| default` (sprig function) with native `{{ if }}` conditionals in the Alertmanager Slack notification template.

## Why
Alertmanager Go template engine does not include sprig functions. Every Slack notification has been failing for 13+ hours with:
```
template: :3: function "default" not defined
```
Zero alerts have reached #alerts since ~10:25 AM CT on 3/25.

## Impact
- Restores Slack alert delivery to #alerts
- No functional change to alert content — same fields, same fallback logic
- ArgoCD auto-sync will roll this out automatically

## Rollback
Revert this commit.