### PR TITLE
fix: harden arr probe tolerance for NFS-backed SQLite

### DIFF
--- a/k8s/clusters/homelabk8s01/apps/arr/radarr/application.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/radarr/application.yml
@@ -49,7 +49,7 @@ spec:
                         port: 7878
                       periodSeconds: 10
                       timeoutSeconds: 10
-                      failureThreshold: 3
+                      failureThreshold: 5
                   readiness:
                     enabled: true
                     custom: true
@@ -59,7 +59,7 @@ spec:
                         port: 7878
                       periodSeconds: 10
                       timeoutSeconds: 10
-                      failureThreshold: 3
+                      failureThreshold: 5
                   startup:
                     enabled: true
                     custom: true
@@ -68,7 +68,7 @@ spec:
                         path: /ping
                         port: 7878
                       periodSeconds: 5
-                      timeoutSeconds: 5
+                      timeoutSeconds: 10
                       failureThreshold: 30
 
         service:

--- a/k8s/clusters/homelabk8s01/apps/arr/sonarr/application.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/sonarr/application.yml
@@ -49,7 +49,7 @@ spec:
                         port: 8989
                       periodSeconds: 10
                       timeoutSeconds: 10
-                      failureThreshold: 3
+                      failureThreshold: 5
                   readiness:
                     enabled: true
                     custom: true
@@ -59,7 +59,7 @@ spec:
                         port: 8989
                       periodSeconds: 10
                       timeoutSeconds: 10
-                      failureThreshold: 3
+                      failureThreshold: 5
                   startup:
                     enabled: true
                     custom: true
@@ -68,7 +68,7 @@ spec:
                         path: /ping
                         port: 8989
                       periodSeconds: 5
-                      timeoutSeconds: 5
+                      timeoutSeconds: 10
                       failureThreshold: 30
 
         service:


### PR DESCRIPTION
## What
Increase liveness/readiness `failureThreshold` from 3→5 and startup probe `timeoutSeconds` from 5→10 for both Sonarr and Radarr.

## Why
Both apps use SQLite databases on NFS-backed PVCs. During heavy write operations (RSS sync, DB migrations), the HTTP server blocks and `/ping` probes time out. With `failureThreshold: 3` the liveness probe kills the pod after just 30s of unresponsiveness, triggering crash loops.

Radarr crash-looped tonight (PodCrashLooping alert fired 04:21→04:53 UTC). Sonarr is still flapping with 6 restarts on the current pod.

## Changes
- **Startup probe:** timeout 5s→10s (total window stays 5min with 30 retries)
- **Liveness probe:** failureThreshold 3→5 (tolerates 50s of unresponsiveness before kill)
- **Readiness probe:** failureThreshold 3→5 (reduces traffic flapping)

## Impact
Slightly slower detection of genuinely dead pods (50s vs 30s). Significantly reduces false-positive kills during NFS I/O stalls.

## Rollback
Revert this commit.