### PR TITLE
fix: widen sonarr probe tolerances for NFS latency spikes

### DIFF
--- a/k8s/clusters/homelabk8s01/apps/arr/sonarr/application.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/sonarr/application.yml
@@ -47,9 +47,9 @@ spec:
                       httpGet:
                         path: /ping
                         port: 8989
-                      periodSeconds: 10
-                      timeoutSeconds: 10
-                      failureThreshold: 5
+                      periodSeconds: 30
+                      timeoutSeconds: 15
+                      failureThreshold: 10
                   readiness:
                     enabled: true
                     custom: true
@@ -57,8 +57,8 @@ spec:
                       httpGet:
                         path: /ping
                         port: 8989
-                      periodSeconds: 10
-                      timeoutSeconds: 10
+                      periodSeconds: 15
+                      timeoutSeconds: 15
                       failureThreshold: 5
                   startup:
                     enabled: true
@@ -68,7 +68,7 @@ spec:
                         path: /ping
                         port: 8989
                       periodSeconds: 5
-                      timeoutSeconds: 10
+                      timeoutSeconds: 15
                       failureThreshold: 30
 
         service:


### PR DESCRIPTION
## What
Widen Sonarr liveness probe tolerances to prevent crash loops caused by NFS-backed SQLite latency.

## Why
Sonarr `/ping` endpoint observed taking **4.2s** during normal operation (RSS sync + SQLite over NFS). Under load it exceeds the 10s timeout entirely — causing liveness failures and a crash loop (8 restarts in 30 min, alert `PodCrashLooping`).

Previous commits already bumped `failureThreshold` 3→5 and `timeoutSeconds` 5→10, but insufficient. Root cause is SQLite WAL flushes blocking the .NET thread pool over NFS.

## Changes
| Probe | Field | Before | After |
|-------|-------|--------|-------|
| Liveness | periodSeconds | 10 | 30 |
| Liveness | timeoutSeconds | 10 | 15 |
| Liveness | failureThreshold | 5 | 10 |
| Readiness | periodSeconds | 10 | 15 |
| Readiness | timeoutSeconds | 10 | 15 |
| Startup | timeoutSeconds | 10 | 15 |

Liveness now tolerates ~5 min of unresponsiveness before killing (was ~100s). Readiness pulls from service faster with unchanged threshold.

## Rollback
Revert this commit.

## Long-term
Consider migrating Sonarr config PVC to local storage (or emptyDir + backup) to eliminate SQLite-over-NFS as a failure mode entirely.