### PR TITLE
fix: widen radarr probe tolerances for NFS latency spikes

### DIFF
--- a/k8s/clusters/homelabk8s01/apps/arr/radarr/application.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/radarr/application.yml
@@ -47,9 +47,9 @@ spec:
                       httpGet:
                         path: /ping
                         port: 7878
-                      periodSeconds: 10
-                      timeoutSeconds: 10
-                      failureThreshold: 5
+                      periodSeconds: 30
+                      timeoutSeconds: 15
+                      failureThreshold: 10
                   readiness:
                     enabled: true
                     custom: true
@@ -57,8 +57,8 @@ spec:
                       httpGet:
                         path: /ping
                         port: 7878
-                      periodSeconds: 10
-                      timeoutSeconds: 10
+                      periodSeconds: 15
+                      timeoutSeconds: 15
                       failureThreshold: 5
                   startup:
                     enabled: true
@@ -68,7 +68,7 @@ spec:
                         path: /ping
                         port: 7878
                       periodSeconds: 5
-                      timeoutSeconds: 10
+                      timeoutSeconds: 15
                       failureThreshold: 30
 
         service:


### PR DESCRIPTION
## What
Relax Radarr liveness/readiness/startup probes to match the tolerances applied to Sonarr in PR #24.

## Why
Radarr is crash-looping (4 restarts in 46m) due to intermittent NFS latency causing `/ping` probe timeouts (`context deadline exceeded`). The app starts and runs fine — the probes are just too tight for NFS-backed SQLite.

## Changes
- Liveness: period 10→30s, timeout 10→15s, failure 5→10
- Readiness: period 10→15s, timeout 10→15s
- Startup: timeout 10→15s

## Rollback
Revert this commit.