### PR TITLE
fix(arr): phase 8 groundwork — roadmap, defect fixes, recyclarr bump

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: hashicorp/setup-packer@main
       - run: packer fmt -check -recursive packer/
       - working-directory: packer/k8s-node
+        env:
+          PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           packer init .
           packer validate \

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ SECRET_PATH ?=
 KEY ?=
 VAL ?=
 
-.PHONY: k8s-init k8s-plan k8s-infra k8s-configure k8s-deploy k8s-destroy k8s-bootstrap cilium-upgrade k8s-backup k8s-backup-status k8s-restore k8s-kubeconfig k8s-ssh-cp vault-init vault-put-secret vault-status aws-init aws-plan aws-apply
+.PHONY: k8s-init k8s-plan k8s-infra k8s-configure k8s-deploy k8s-destroy k8s-bootstrap cilium-upgrade k8s-backup k8s-backup-status k8s-restore k8s-kubeconfig k8s-ssh-cp vault-init vault-put-secret vault-status arr-keys-adopt aws-init aws-plan aws-apply
 
 k8s-init: ## Initialize Terraform for K8s VMs
 	terraform -chdir=$(TF_DIR) init
@@ -123,7 +123,7 @@ k8s-bootstrap: ## Install ArgoCD and root app-of-apps (one-time)
 	kubectl apply -k k8s/bootstrap/argocd/
 	@echo "Waiting for ArgoCD to be ready..."
 	kubectl -n argocd wait --for=condition=available deployment/argocd-server --timeout=300s
-	kubectl apply -f k8s/bootstrap/root-app.yml
+	kubectl apply -k k8s/bootstrap/applicationsets/
 
 k8s-backup: ## Trigger an on-demand Velero backup of all namespaces
 	velero backup create manual-$$(date +%Y%m%d-%H%M%S) \
@@ -171,6 +171,27 @@ vault-put-secret: ## Write a secret to Vault (usage: make vault-put-secret SECRE
 	@sleep 3
 	@VAULT_ADDR=http://127.0.0.1:8200 vault kv patch homelab/$(SECRET_PATH) $(KEY)="$(VAL)" 2>/dev/null \
 		|| VAULT_ADDR=http://127.0.0.1:8200 vault kv put homelab/$(SECRET_PATH) $(KEY)="$(VAL)"
+	@kill %% 2>/dev/null || true
+
+arr-keys-adopt: ## Copy each *arr app's live API key into Vault at homelab/apps/arr (never prints the key)
+	@if [ -z "$$VAULT_TOKEN" ]; then echo "Error: VAULT_TOKEN not set. Export your root token first: export VAULT_TOKEN=hvs.xxxxx"; exit 1; fi
+	@lsof -ti:8200 | xargs kill 2>/dev/null || true
+	@kubectl --kubeconfig ./kubeconfig port-forward -n $(VAULT_NS) pod/vault-0 8200:8200 >/dev/null 2>&1 &
+	@sleep 3
+	@for app in sonarr radarr prowlarr; do \
+		key=$$(kubectl --kubeconfig ./kubeconfig -n arr exec deploy/arr-$$app -c main -- \
+			sed -n 's:.*<ApiKey>\(.*\)</ApiKey>.*:\1:p' /config/config.xml 2>/dev/null); \
+		if [ -z "$$key" ]; then echo "  $$app: FAILED to read /config/config.xml"; continue; fi; \
+		VAULT_ADDR=http://127.0.0.1:8200 vault kv patch homelab/apps/arr $$app-api-key="$$key" >/dev/null 2>&1 \
+			|| VAULT_ADDR=http://127.0.0.1:8200 vault kv put homelab/apps/arr $$app-api-key="$$key" >/dev/null; \
+		echo "  $$app: adopted"; \
+	done
+	@key=$$(kubectl --kubeconfig ./kubeconfig -n arr exec deploy/arr-bazarr -c main -- \
+		sed -n 's/^[[:space:]]*apikey:[[:space:]]*//p' /config/config/config.yaml 2>/dev/null | head -1); \
+	if [ -z "$$key" ]; then echo "  bazarr: FAILED to read config.yaml"; else \
+		VAULT_ADDR=http://127.0.0.1:8200 vault kv patch homelab/apps/arr bazarr-api-key="$$key" >/dev/null 2>&1 \
+			|| VAULT_ADDR=http://127.0.0.1:8200 vault kv put homelab/apps/arr bazarr-api-key="$$key" >/dev/null; \
+		echo "  bazarr: adopted"; fi
 	@kill %% 2>/dev/null || true
 
 vault-status: ## Show Vault seal status

--- a/docs/roadmap/assessment.md
+++ b/docs/roadmap/assessment.md
@@ -63,6 +63,45 @@ Analysis of the homelab's current strengths and gaps, used to prioritize the [ro
 | K15 | **No cert-manager health alerting** | cert-manager pod failures or renewal errors are not monitored. | Low |
 | K16 | **No etcd snapshot schedule** | Single control plane with no dedicated etcd backup. Velero backs up API resources but an etcd corruption or quorum loss requires a snapshot to restore. | Resolved |
 | K17 | **No Loki retention policy** | Logs grow unbounded on NFS. No compaction or retention limits configured. | Resolved |
+| K18 | **`make k8s-bootstrap` applies a deleted file** | `Makefile:126` runs `kubectl apply -f k8s/bootstrap/root-app.yml`, removed in `7742cb0`. Nothing applies `k8s/bootstrap/applicationsets/`. The documented rebuild path -- step 1 of the DR runbook -- fails on its first command. | Critical |
+| K19 | **Media share and cluster storage share are the same NFS export** | `nfs-provisioner/values.yml` provisions dynamic PVCs as `0777` subdirectories of the exact path `shared-data-pv.yml` exports. Every *arr container mounts a directory whose siblings are Vault storage, the MinIO bucket holding Velero backups, Loki, and Authentik's database. Also makes every PVC capacity alert measure the same filesystem. | Critical |
+| K20 | **ArgoCD's pinned CA certificate expired** | `k8s/bootstrap/argocd/custom-ca.yml` embeds a literal PEM (`CN=homelab-ca`, 90-day validity, issued 2026-03-23, expired 2026-06-21) mounted into `argocd-server`. cert-manager rotates the real CA; this copy does not follow. No x509 errors appear in current `argocd-server` logs, so the impact is latent -- it surfaces the next time ArgoCD must validate a `*.homelab.local` certificate. | Medium |
+| K21 | **The *arr apps are not behind SSO, and the docs say they are** | `docs/architecture/auth.md` describes nginx-ingress `auth_request` forward-auth protecting Sonarr, Radarr, Prowlarr and qBittorrent. The cluster runs `gatewayClassName: cilium` and contains no `nginx.ingress.kubernetes.io/*` annotation. Every *arr UI is open on the LAN. | High |
+| K22 | **CI never renders manifests** | `validate.yml` runs kubeconform over individual files but ignores `config.yml` and `values.yml` -- the only two file types the ApplicationSet consumes -- and never runs `kustomize build`, `helm template`, or the Kyverno CLI. K18, K23 and K26 would all have been caught by a render job. | High |
+| K23 | **Renovate proposes no Helm chart bumps** | Renovate's `argocd` manager only reads YAML whose `kind` is `Application`/`ApplicationSet`. Since the ApplicationSet migration, chart versions live in schema-less `config.yml` files no manager matches. ~30 chart versions are silently hand-maintained. | High |
+| K24 | **No dependency ordering between Applications** | The applicationset-controller creates Application objects directly with no parent Application syncing them, so `argocd.argoproj.io/sync-wave` on a generated Application is inert -- including the one in `local-path-provisioner/config.yml`. Ordering is `retry: limit 10` plus luck. | Medium |
+| K25 | **Recyclarr has failed every run for ~61 days** | ArgoCD reports `arr-recyclarr` Degraded; the last success was 2026-06-02. The visible error (`Could not find color or style '<revision>...'`) is a known Recyclarr crash when resource-provider error messages contain special characters, fixed upstream in 8.6.0 -- `values.yml` pins 8.5.1. The crash masks the underlying resource-provider failure, so the real cause is still unknown. The one piece of *arr config already in Git has not applied in two months. | High |
+| K26 | **Seerr's HTTPRoute is dead code** | `apps/arr/seerr/httproute.yml` is in Git and passes CI but is listed in no `kustomization.yml`, and `values.yml` sets `route.main.enabled: false`. Nothing creates the route. | Medium |
+| K27 | **Unpackerr is a silent no-op** | It has been returning `401` from both Sonarr and Radarr continuously for 16+ weeks -- the API keys in `unpackerr-secrets` no longer match the ones the apps generated, which is C1 manifesting in production. Separately, `UN_SONARR_0_PATHS` / `UN_RADARR_0_PATHS` are unset and default to `/downloads`, a path the pod does not mount, and it runs as UID 1000 against a share that squashes to 977:988. All three must be fixed for it to do anything. | High |
+
+### Configuration Layer
+
+Runtime state that lives inside an application's own database rather than in Git. Recorded only as prose in `docs/apps/*.md` "Post-Deploy Setup" sections -- roughly 120 individual settings across 18 categories.
+
+| # | Gap | Risk | Severity |
+|---|-----|------|----------|
+| C1 | **\*arr API keys are self-generated and hand-copied into Vault** | Sonarr, Radarr, Prowlarr and Bazarr each generate a key into `/config/config.xml` on first boot. Eight consumers depend on those keys, so a cold rebuild deadlocks until a human visits four web UIs. Blocks every other item in this table. | Critical |
+| C2 | **Prowlarr indexer definitions and private-tracker passkeys exist only in SQLite** | The least reproducible state in the homelab. Some passkeys cannot be re-obtained without contacting a tracker. | Critical |
+| C3 | **Prowlarr's app-sync to Sonarr/Radarr is manual** | Without it, indexers added to Prowlarr never reach Sonarr or Radarr and the centralised-indexer benefit evaporates. | High |
+| C4 | **Sonarr/Radarr root folders and download-client wiring are click-ops** | Neither app will accept a series or movie without a root folder, and nothing creates the directories they point at. | High |
+| C5 | **Jellyfin's setup wizard, admin account, libraries and hardware transcoding are manual** | The entire GPU path is codified -- Proxmox PCI mapping, node selector, device plugin -- except the one setting that makes Jellyfin use it. | High |
+| C6 | **Bazarr, Seerr, qBittorrent and Tdarr configuration is entirely UI state** | Subtitle providers, language profiles, service registrations, download categories, and a 10-node transcode flow graph. | High |
+| C7 | **Authentik providers, applications, outposts and OAuth2 client secrets are 12 UI steps** | The longest post-deploy procedure in the repo. Client secrets are generated in the UI and hand-copied into Vault, inverting the intended direction. | High |
+| C8 | **Uptime Kuma's admin account, 18 monitors and status page are hand-created** | Its API is socket.io-only with no supported REST write path, making the monitoring-of-last-resort the least reproducible app in the repo. | Medium |
+| C9 | **NAS export layout and the media directory tree are undocumented manual setup** | `shared-data-pv.yml` hardcodes a volume UUID that will differ on any replacement NAS, and nothing creates `/data/media/{movies,tv,music}`. | Medium |
+
+### Media Platform
+
+Gaps measured against the goal of replacing streaming subscriptions rather than against infrastructure correctness.
+
+| # | Gap | Risk | Severity |
+|---|-----|------|----------|
+| M1 | **Acquisition is torrent-only** | A single gluetun + qBittorrent pod dependent on swarm health and on PIA continuing to forward a port. For back catalogue and non-English content this is where a request fails -- and a failed request is what sends a household back to streaming. | High |
+| M2 | **Nothing works off-LAN** | Jellyfin is a LoadBalancer behind a self-signed CA at `jellyfin.homelab.local`. Family cannot watch anywhere, and TV clients will not accept a private CA. | High |
+| M3 | **No retention policy against a hard capacity ceiling** | `shared-data-pv.yml` declares `capacity: 10Ti` against one 8 TB drive; NFS PVs enforce no quota, so nothing warns before writes fail. Nothing deletes anything, and media is deliberately excluded from backup. | High |
+| M4 | **No library-freshness mechanism** | Media lives on NFS and inotify does not work across NFS, so Jellyfin's real-time monitor is unreliable -- imports appear only on scheduled scans. | Medium |
+| M5 | **No household UX layer** | No watch analytics, no invites, no collections, no resume continuity, and none of the free Jellyfin plugins (Intro Skipper, TMDB Box Sets, Playback Reporting, Trakt) installed. | Medium |
+| M6 | **Transcode policy is contradictory and unstated** | `recyclarr/configmap.yml` scores `x265 (HD)` as unwanted on both profiles while Tdarr is deployed to transcode. If Tdarr targets HEVC it manufactures exactly the files Recyclarr rejects, plus a generation of quality loss. | Medium |
 
 ## Gap-to-Phase Mapping
 
@@ -70,8 +109,9 @@ Analysis of the homelab's current strengths and gaps, used to prioritize the [ro
 |-----|-------------|
 | P2 | [Phase 1 -- Foundations](phase-1-foundations.md) |
 | K3, K9, K11, K15, N6 | [Phase 2 -- Kubernetes Hardening](phase-2-kubernetes-hardening.md) |
-| P3, N3, N4, N5 | [Phase 3 -- Network](phase-3-network.md) |
+| P3, N3, N4, N5, M2 | [Phase 3 -- Network](phase-3-network.md) |
 | P4, K1, K4 | [Phase 4 -- Compute & Storage](phase-4-compute-and-storage.md) |
 | K10, K14, K8 | [Phase 5 -- Observability](phase-5-observability.md) |
 | K12, K13 | [Phase 6 -- Platform Engineering](phase-6-platform-engineering.md) |
 | P5, N2 | [Phase 7 -- Long-Term Vision](phase-7-long-term-vision.md) |
+| C1--C9, K18--K27, M1, M3--M6 | [Phase 8 -- Configuration as Code](phase-8-configuration-as-code.md) |

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -15,6 +15,7 @@ For current infrastructure details, see [Hardware Inventory](../reference/hardwa
 | [5 -- Observability](phase-5-observability.md) | Distributed tracing, dashboards-as-code, SLO alerting, synthetic monitoring | Not started |
 | [6 -- Platform Engineering](phase-6-platform-engineering.md) | Staging cluster, Falco, chaos engineering, supply chain security, vPro AMT | Not started |
 | [7 -- Long-Term Vision](phase-7-long-term-vision.md) | Third host, Crossplane, multi-cluster GitOps, dedicated GPU, full 10G | Not started |
+| [8 -- Configuration as Code](phase-8-configuration-as-code.md) | \*arr config-as-code, custom controller, Authentik blueprints, media platform gaps | Not started |
 
 ## Assessment
 

--- a/docs/roadmap/phase-8-configuration-as-code.md
+++ b/docs/roadmap/phase-8-configuration-as-code.md
@@ -1,0 +1,130 @@
+# Phase 8 -- Configuration as Code
+
+**Status:** Not started
+
+**Goal:** Extend reproducibility past the pod boundary. Today the pipeline rebuilds every layer from bare metal up to running containers and then stops -- every setting *inside* an application is hand-entered in a web UI. Close that gap with a purpose-built Kubernetes operator.
+
+**Addresses:** [C1--C9](assessment.md#configuration-layer), [K18--K27](assessment.md#kubernetes-software-layer), [M1, M3--M6](assessment.md#media-platform)
+
+---
+
+## 8.1 Fix the Blocking Defects
+
+- [ ] Replace `Makefile:126` with `kubectl apply -k k8s/bootstrap/applicationsets/` (K18)
+- [ ] Give the media share its own export root -- point `nfs-provisioner/values.yml` at a sibling directory and re-provision (K19)
+- [ ] Replace ArgoCD's literal CA PEM with a trust-manager Bundle or a cert-manager `additionalOutputFormat` (K20)
+- [ ] Bump Recyclarr past 8.6.0 to unmask the real error, then fix whatever it reports (K25)
+- [ ] Add `- httproute.yml` to `apps/arr/seerr/kustomization.yml` and flip `route.main.enabled` (K26)
+- [ ] Set `UN_SONARR_0_PATHS_0` / `UN_RADARR_0_PATHS_0` to `/data/torrents`; change Unpackerr to UID 977 / GID 988 (K27). Its 401s are fixed by 8.2, not here
+- [ ] Add a `render` job to `validate.yml`: `kustomize build` per directory, `helm template` per `config.yml` (K22)
+- [ ] Add a Renovate `customManager` matching the `chartRepo`/`chartName`/`chartVersion` keys in `config.yml` (K23)
+- [ ] Reconcile `docs/architecture/auth.md` with reality, and decide whether to build Gateway API forward-auth (K21)
+
+| | |
+|---|---|
+| **Why** | The rebuild path is broken today, so none of the work below can be tested from zero. Recyclarr may never have applied, which makes the Configarr comparison in 8.3 meaningless. And CI that never renders a manifest is how three of these shipped unnoticed in the first place. |
+
+## 8.2 Invert the API-Key Flow
+
+- [ ] `make arr-keys` target: `vault kv put homelab/apps/arr <app>-api-key=$(openssl rand -hex 16)` for all four apps
+- [ ] One `arr-api-keys` ExternalSecret in `apps/arr/prereqs/`, ESO-templated to emit both the `APPNAME__AUTH__APIKEY` env names and the plain keys existing consumers read
+- [ ] Add `envFrom.secretRef` alongside the existing `configMapRef: arr-env` in sonarr, radarr and prowlarr `values.yml`
+- [ ] Collapse the duplicate key copies in Vault (`apps/exportarr` and `apps/unpackerr` hold the same Sonarr/Radarr keys)
+- [ ] Destructive test: delete `arr-prowlarr-config`, let it rebuild, confirm the key is unchanged
+
+| | |
+|---|---|
+| **Why** | The single biggest unblock in the repo, and roughly 30 lines of YAML. Today a cold rebuild deadlocks -- four humans-visiting-web-UIs stand between an empty PVC and eight consumers. After this, `kubectl delete pvc` on any *arr config volume is survivable. |
+| **Verified** | The `APP__SECTION__KEY` env override landed in Sonarr v4.0.4.1699 (2024-05-24) and was cherry-picked to Radarr the same month. The cluster runs Sonarr 4.0.17, Radarr 6.0.4, Prowlarr 2.3.0. Seerr takes `API_KEY` directly. |
+| **Do not** | Set `__AUTH__METHOD: External`. That disables the app's own login on the assumption a proxy authenticates first -- and per K21, nothing does. |
+
+## 8.3 Adopt Configarr
+
+- [ ] Swap the Recyclarr image; `configmap.yml` transplants nearly verbatim -- same YAML dialect, same `!secret` indirection
+- [ ] Retarget the ExternalSecret at the new `arr-api-keys` source
+- [ ] Extend coverage to root folders, download clients with remote path mappings, `media_naming_api`, delay profiles
+- [ ] Resolve the transcode contradiction before touching profiles (M6, see 8.8)
+
+| | |
+|---|---|
+| **Why** | Configarr is the maintained successor and covers meaningfully more surface for near-zero migration cost. |
+| **Optional** | Independent of the operator. Taking it removes `RootFolder`, `DownloadClient` and `ArrSettings` from 8.4's scope; skipping it means the operator owns those too. Note the current `recyclarr/configmap.yml` sets only `quality_definition`, `quality_profiles` and `custom_formats`, so naming and Propers/Repacks are hand-clicked today even though Recyclarr already supports them. |
+
+## 8.4 Build the \*arr Operator
+
+New top-level `operators/arr-operator/`, API group `arr.homelab.local/v1alpha1`, wrapping the `devopsarr` Go SDKs.
+
+- [ ] Scaffold with kubebuilder v4; **pin controller-runtime to the v0.19.x line**, `controller-gen` v0.16.x, `ENVTEST_K8S_VERSION=1.31.0` -- the cluster is on Kubernetes 1.31.4 and controller-runtime tracks one minor per release
+- [ ] Define the CRD taxonomy: `ArrInstance` (root, one per app, owns base URL + `apiKeySecretRef` + liveness), fine-grained kinds for identity-bearing objects (`Indexer`, `ProwlarrApplication`, `Notification`, `DownloadClient`, `RootFolder`, `ImportList`), and `ArrSettings` as a singleton for the PUT-only config structs that have no identity
+- [ ] Declare indexers **only** against the `prowlarr` instance -- Prowlarr's own sync fans them into Sonarr and Radarr, which removes the largest ordering hazard
+- [ ] Write one generic reconciler parameterised by an `Adapter[S]` interface (`List`/`Get`/`Create`/`Update`/`Delete`/`Render`/`SchemaFor`), ~80 lines per kind on top
+- [ ] Gate children on instance readiness: not-Ready requeues 30s and **returns no error**, so it does not enter exponential backoff
+- [ ] Validate against `GET /api/vN/<kind>/schema` before writing, failing fast with the valid field names in the message
+- [ ] **Adopt by name first**, `.status.externalID` second -- the ApplicationSet sets `prune: true` unconditionally and a Velero restore renumbers IDs, both of which break ID-first lookup
+- [ ] Exclude secret-valued fields from read-back diffing (the APIs return `********`); track them via `.status.appliedHash` instead, with an explicit per-CR `driftCheckFields` allowlist
+- [ ] Finalizers with per-kind deletion policy: `Delete` for indexers, clients, notifications and import lists; `Orphan` for `RootFolder`; adoption overrides to `Orphan` unless set explicitly
+- [ ] Give the finalizer a 10-minute give-up path so a dead Sonarr can never wedge `kubectl delete` or an ArgoCD prune
+- [ ] Field index on `.spec.instanceRef.name` plus `.Watches(&ArrInstance{}, ...)` so children requeue the instant an instance goes Ready
+- [ ] Default `reconcileInterval` to 5m, not 1m -- these are SQLite-backed apps
+- [ ] Emit `clapperboard_drift_corrected_total` and a Kubernetes Event on every correction; add a `PrometheusRule` on `increase(...[6h]) > 3`
+- [ ] Provide `driftPolicy: Observe` to record drift without writing
+- [ ] envtest plus an in-memory \*arr fake with recorded `/schema` fixtures
+
+| | |
+|---|---|
+| **Why** | This is the learning goal, against a problem with real ordering constraints (Sonarr key → Prowlarr application → indexer → tag → proxy) rather than toy CRUD. Informers, work queues, finalizers, status conditions, owner refs, SSA, CEL validation and envtest, on a system in daily use. |
+| **Ordering** | Sync waves cannot help. The applicationset-controller creates Applications directly with no parent syncing them, so waves on a generated Application are inert (K24). Correctness comes from readiness gating in the controller; waves only reduce event noise *within* the `arr-config` Application. |
+| **Effort** | **30--45 focused days.** First Go module in the repo, 8 CRDs, a generics-parameterised adapter, an envtest harness, a hand-built API fake, a secret resolver with a redaction type, and adoption-by-name. Plan for 6--10 weekends. |
+
+## 8.5 Package and Ship the Operator
+
+- [ ] Two Applications, not one: `arr-operator` (`gitPath k8s/components/arr-operator`, CRDs + manager) and `arr-config` (CRs, `SkipDryRunOnMissingResource=true`)
+- [ ] Add a `kustomization.yml` to `k8s/components/arr-operator/` -- the existing `kyverno-policies/` is flat and has none, and `templatePatch` cannot set `source.directory.recurse`
+- [ ] Generate CRD schemas and add a `-schema-location` for the new kinds, or the first PR fails kubeconform
+- [ ] Make directory creation (C9) a separate one-shot Job -- **not** a `RootFolder.ensureDirectory` field, which would require mounting the 10Ti `arr-data` PV into the manager and whose `chown` is a no-op or `EPERM` against a UID-squashing NAS
+- [ ] Coerce the OpenClaw webhook `headers` field to JSON -- the deployed payload is an array of `{key, value}` objects, not a string
+- [ ] Add an `instanceRefs` list to fan-out kinds so `Notification` does not need paired CRs that always change together
+- [ ] Keep the app→endpoint table (`sonarr → {8989, v3}`, `radarr → {7878, v3}`, `prowlarr → {9696, v1}`) as one reviewable Go var or ConfigMap, not dispatch logic in a factory
+- [ ] New CI surface: GHCR auth, a tag→deploy flow, and `disallow-latest-tag` (Enforce) applying to the manager's own manifest
+- [ ] Retire `apps/openclaw/boot-configmap.yml`'s notification reconciliation
+
+| | |
+|---|---|
+| **Scope** | The devopsarr provider exposes 81 Sonarr resources. Eight kinds is ~15% of the settings surface and that is the right answer -- it closes roughly 60% of the configuration inventory. Everything else is 8.6. |
+
+## 8.6 The Long Tail
+
+Bootstrap Jobs and seeded config files, not controller work.
+
+- [ ] **Jellyfin** (C5): one Job hitting `/Startup/Configuration`, `/Startup/User`, `/Library/VirtualFolders`, then `/System/Configuration/encoding` to enable QSV
+- [ ] **Authentik** (C7): blueprints in `/blueprints/custom/` for providers, applications, outposts, flows and groups, with client secrets from `!Env` so Vault becomes the source rather than the destination
+- [ ] **Seerr** (C6): `/api/v1/settings/{jellyfin,radarr,sonarr}` + `initialize`
+- [ ] **qBittorrent** (C6): seed `qBittorrent.conf` from a ConfigMap + initContainer with a PBKDF2 hash derived from the Vault password; ship `categories.json`
+- [ ] **Bazarr** (C6): template `/config/config/config.yaml` -- the API is too weak to drive
+- [ ] **Tdarr** (C6): export the flow as JSON, commit it, POST via `/api/v2/cruddb`
+- [ ] **Uptime Kuma** (C8): no REST write API exists -- replace the monitor list with `blackbox-exporter` and Git-committed `Probe` resources
+- [ ] **NAS layout** (C9): move the volume UUID out of the PV manifest into documented configuration
+
+## 8.7 Media Platform
+
+- [ ] Install the Jellyfin plugins -- Intro Skipper, TMDB Box Sets, Playback Reporting, Trakt (M5). Resize `jellyfin/pvc.yml` past its current 5Gi first; trickplay plus fingerprints will not fit
+- [ ] Add a PrometheusRule on NFS free space with a `predict_linear` forecast (M3)
+- [ ] Add a Usenet path: SABnzbd as a standalone controller (not inside the gluetun pod), a provider and an indexer (M1). `arr-egress` allows world egress on TCP/443 only -- 563 must be added
+- [ ] Deploy Janitorr in dry-run for retention, and leave it there until the NAS mirror exists (M3)
+- [ ] Add a scheduled library refresh to work around NFS inotify (M4)
+
+| | |
+|---|---|
+| **Why** | M1 and M3 are what decide whether the platform replaces streaming or gets abandoned: a request that fails sends a household back to Netflix, and a library with no ceiling eventually stops accepting writes. Off-LAN access (M2) is tracked in [Phase 3](phase-3-network.md). |
+
+## 8.8 Decisions to Record
+
+- [ ] **ADR-018 -- \*arr configuration as code.** The CRD taxonomy and reconcile semantics from 8.4, and why a purpose-built operator over Crossplane + provider-terraform (the fallback reaches fuller coverage without hand-written field mappings, but teaches composition rather than controllers, and Kyverno's `require-resource-limits` in Enforce mode rejects Crossplane's synthesised provider Deployments until `crossplane-system` is excluded)
+- [ ] **ADR-019 -- transcode policy.** Resolve M6: whether the library targets x264 acquisition with in-house HEVC re-encoding, or native HEVC. Defensible either way; currently whichever Tdarr flow happens to be enabled decides it
+- [ ] Amend ADR-010 or `docs/architecture/auth.md` to describe the auth mechanism that actually exists (K21)
+
+---
+
+## What Stays Click-Ops
+
+After all of the above: Grafana ad-hoc explores, Alertmanager silences (correctly ephemeral), Jellyfin per-user watch state and playback positions, Tdarr's visual flow editor beyond import/export, and OpenClaw's Control-UI settings that live on the PVC by design. None of it is state worth mourning.

--- a/k8s/clusters/homelabk8s01/apps/arr/recyclarr/values.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/recyclarr/values.yml
@@ -15,7 +15,7 @@ controllers:
       main:
         image:
           repository: ghcr.io/recyclarr/recyclarr
-          tag: 8.5.1
+          tag: 8.7.0
         args:
           - sync
         securityContext:

--- a/k8s/clusters/homelabk8s01/apps/arr/seerr/kustomization.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/seerr/kustomization.yml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - httproute.yml
   - pvc.yml

--- a/k8s/clusters/homelabk8s01/apps/arr/unpackerr/values.yml
+++ b/k8s/clusters/homelabk8s01/apps/arr/unpackerr/values.yml
@@ -2,9 +2,9 @@ defaultPodOptions:
   annotations:
     backup.velero.io/backup-volumes-excludes: data
   securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
+    runAsUser: 977
+    runAsGroup: 988
+    fsGroup: 988
     runAsNonRoot: true
 controllers:
   main:
@@ -16,7 +16,9 @@ controllers:
         env:
           UN_WEBSERVER_METRICS: 'true'
           UN_SONARR_0_URL: http://arr-sonarr.arr.svc.cluster.local:8989
+          UN_SONARR_0_PATHS_0: /data/torrents
           UN_RADARR_0_URL: http://arr-radarr.arr.svc.cluster.local:7878
+          UN_RADARR_0_PATHS_0: /data/torrents
           UN_QBIT_0_URL: http://arr-vpn-downloads.arr.svc.cluster.local:8080
         envFrom:
           - configMapRef:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
       - "Phase 5: Observability": roadmap/phase-5-observability.md
       - "Phase 6: Platform Engineering": roadmap/phase-6-platform-engineering.md
       - "Phase 7: Long-Term Vision": roadmap/phase-7-long-term-vision.md
+      - "Phase 8: Configuration as Code": roadmap/phase-8-configuration-as-code.md
   - Reference:
       - Commands: reference/commands.md
       - Service URLs: reference/service-urls.md


### PR DESCRIPTION
Groundwork for [Phase 8 — Configuration as Code](docs/roadmap/phase-8-configuration-as-code.md).

## Defects fixed

| Gap | Fix |
|-----|-----|
| K18 | `make k8s-bootstrap` applied `k8s/bootstrap/root-app.yml`, deleted in `7742cb0`. Now applies the ApplicationSet. The documented rebuild path failed on its first command. |
| K25 | Recyclarr pinned to 8.5.1, which crashes rendering resource-provider errors containing special characters. 8.6.0 fixed that. Bumped to 8.7.0 to unmask the real error — it has failed every run since 2026-06-02. |
| K26 | `seerr/httproute.yml` was in git but listed in no `kustomization.yml`, so `seerr.homelab.local` resolved to nothing. |
| K27 | Unpackerr had no `UN_*_PATHS`, defaulting to `/downloads` — a path it does not mount — and ran as UID 1000 against a share that squashes to 977:988. |
| — | `packer init` fetched plugins unauthenticated and hit GitHub's API rate limit when CI runs bunched up. |

## Docs

New Phase 8 roadmap. `assessment.md` gains K18–K27, a Configuration Layer (C1–C9) and a Media Platform section (M1–M6), with the gap-to-phase mapping updated.

## Verification

`kustomize build` passes on the changed directories; seerr now renders both the PVC and the HTTPRoute. Cluster is healthy on the newly-merged Renovate images.